### PR TITLE
Fix: Reflector and absorber rods now turn off...

### DIFF
--- a/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorRodAbsorber.java
+++ b/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorRodAbsorber.java
@@ -49,7 +49,7 @@ public class MultiTileEntityReactorRodAbsorber extends MultiTileEntityReactorRod
 	
 	@Override
 	public int getReactorRodNeutronReflection(MultiTileEntityReactorCore aReactor, int aSlot, ItemStack aStack, int aNeutrons) {
-		aReactor.mNeutronCounts[aSlot] += aNeutrons;
+		aReactor.mNeutronCounts[aSlot] += aReactor.mStopped ? 0 : aNeutrons;
 		return 0;
 	}
 	

--- a/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorRodReflector.java
+++ b/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorRodReflector.java
@@ -48,7 +48,7 @@ public class MultiTileEntityReactorRodReflector extends MultiTileEntityReactorRo
 	
 	@Override
 	public int getReactorRodNeutronReflection(MultiTileEntityReactorCore aReactor, int aSlot, ItemStack aStack, int aNeutrons) {
-		return aNeutrons;
+		return aReactor.mStopped ? 0 : aNeutrons;
 	}
 	
 	@Override public String getTileEntityName() {return "gt.multitileentity.generator.reactor.rods.reflector";}


### PR DESCRIPTION
...when reactor is shut down with soft hammer.

Implementing these changes could also be done on the reactor tile entities, but I find this way a bit cleaner, than adding a bunch of checks to the reactor tile entities.