### PR TITLE
Few commits, one build.gradle enhancement, rest for ASM for thaumcraft

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -313,10 +313,16 @@ dependencies {
 
 runClient {
 	jvmArgs "-Xmx4096m", "-Xms1024m"
+	if (project.hasProperty("appArgs")) {
+		args Eval.me(appArgs)
+	}
 }
 
 runServer {
 	jvmArgs "-Xmx4096m", "-Xms1024m"
+	if (project.hasProperty("appArgs")) {
+		args Eval.me(appArgs)
+	}
 }
 
 task buildInfo {

--- a/src/main/java/gregtech/asm/GT_ASM.java
+++ b/src/main/java/gregtech/asm/GT_ASM.java
@@ -72,6 +72,7 @@ public class GT_ASM implements IFMLLoadingPlugin {
 
 			transformers.put(CoFHCore_CrashFix.class.getName(), true);
 			transformers.put(Technomancy_ExtremelySlowLoadFix.class.getName(), true);
+			transformers.put(Thaumcraft_AspectLagFix.class.getName(), true);
 
 			mclocation = new File(mclocation, "/config/gregtech");
 			mclocation.mkdirs();

--- a/src/main/java/gregtech/asm/transformers/Thaumcraft_AspectLagFix.java
+++ b/src/main/java/gregtech/asm/transformers/Thaumcraft_AspectLagFix.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2020 GregTech-6 Team
+ *
+ * This file is part of GregTech.
+ *
+ * GregTech is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GregTech is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GregTech. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package gregtech.asm.transformers;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.IntHashMap;
+import net.minecraft.util.ObjectIntIdentityMap;
+import net.minecraft.util.Tuple;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+import scala.Int;
+import scala.Predef;
+import scala.Tuple2;
+
+import java.util.HashMap;
+
+public class Thaumcraft_AspectLagFix implements IClassTransformer {
+	@Override
+	public byte[] transform(String name, String transformedName, byte[] basicClass) {
+		if (!name.equals("thaumcraft.common.lib.research.ScanManager")) return basicClass;
+
+		ClassNode classNode = new ClassNode();
+		ClassReader classReader = new ClassReader(basicClass);
+		classReader.accept(classNode, 0);
+
+		for (MethodNode m: classNode.methods) {
+			if (m.name.equals("generateItemHash")) { // Should check `desc` too but no ambiguity here anyway
+				LabelNode first = (LabelNode)m.instructions.get(0);
+				m.instructions.insertBefore(first, new VarInsnNode(Opcodes.ALOAD, 0)); // Load item
+				m.instructions.insertBefore(first, new VarInsnNode(Opcodes.ILOAD, 1)); // load meta
+				m.instructions.insertBefore(first, new MethodInsnNode(Opcodes.INVOKESTATIC, "gregtech/asm/transformers/Thaumcraft_AspectLagFix", "getCachedItemHash", "(Lnet/minecraft/item/Item;I)I", false));
+				m.instructions.insertBefore(first, new InsnNode(Opcodes.DUP)); // duplicate return
+				m.instructions.insertBefore(first, new JumpInsnNode(Opcodes.IFEQ, first)); // If 0 jump to label0
+				m.instructions.insertBefore(first, new InsnNode(Opcodes.IRETURN));
+				m.instructions.insert(first, new InsnNode(Opcodes.POP)); // Pop the duplicate possible return value that's actually now 0
+
+				for (AbstractInsnNode node = first.getNext(); node != null; node = node.getNext()) {
+					if (node instanceof InsnNode) {
+						InsnNode ret = (InsnNode)node;
+						if (ret.getOpcode() == Opcodes.IRETURN) {
+							m.instructions.insertBefore(ret, new VarInsnNode(Opcodes.ALOAD, 0)); // Load item, hash is already on the stack
+							m.instructions.insertBefore(ret, new VarInsnNode(Opcodes.ILOAD, 1)); // load meta
+							m.instructions.insertBefore(ret, new MethodInsnNode(Opcodes.INVOKESTATIC, "gregtech/asm/transformers/Thaumcraft_AspectLagFix", "setCachedItemHash", "(ILnet/minecraft/item/Item;I)I", false));
+						}
+					}
+				}
+			}
+		}
+
+		ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+		classNode.accept(writer);
+		return writer.toByteArray();
+	}
+
+	private static HashMap<Item, IntHashMap> cacheItemHash = new HashMap<>();
+
+	public static int getCachedItemHash(Item item, int meta) {
+		IntHashMap metaMap = cacheItemHash.get(item);
+		if (metaMap != null) {
+			Integer hash = (Integer)metaMap.lookup(meta);
+			if (hash != null) return hash;
+		}
+		return 0;
+	}
+
+	public static int setCachedItemHash(int hash, Item item, int meta) {
+		IntHashMap metaMap = cacheItemHash.get(item);
+		if (metaMap == null) metaMap = cacheItemHash.put(item, new IntHashMap());
+		metaMap.addKey(meta, hash);
+		return hash;
+	}
+}

--- a/src/main/java/gregtech/asm/transformers/Thaumcraft_AspectLagFix.java
+++ b/src/main/java/gregtech/asm/transformers/Thaumcraft_AspectLagFix.java
@@ -22,73 +22,140 @@ package gregtech.asm.transformers;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IntHashMap;
-import net.minecraft.util.ObjectIntIdentityMap;
-import net.minecraft.util.Tuple;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.*;
 
 import net.minecraft.launchwrapper.IClassTransformer;
-import scala.Int;
-import scala.Predef;
-import scala.Tuple2;
+import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.api.aspects.AspectList;
 
+import java.util.Arrays;
 import java.util.HashMap;
 
 public class Thaumcraft_AspectLagFix implements IClassTransformer {
+	// TODO:  Probably do same thing to thaumcraft.common.lib.crafting.ThaumcraftCraftingManager.getObjectTags?
 	@Override
 	public byte[] transform(String name, String transformedName, byte[] basicClass) {
-		if (!name.equals("thaumcraft.common.lib.research.ScanManager")) return basicClass;
+		if (name.equals("thaumcraft.common.lib.research.ScanManager")) {
+			ClassNode classNode = new ClassNode();
+			ClassReader classReader = new ClassReader(basicClass);
+			classReader.accept(classNode, 0);
 
-		ClassNode classNode = new ClassNode();
-		ClassReader classReader = new ClassReader(basicClass);
-		classReader.accept(classNode, 0);
+			for (MethodNode m : classNode.methods) {
+				if (m.name.equals("generateItemHash")) { // First most costly thing
+					LabelNode first = (LabelNode) m.instructions.get(0);
+					m.instructions.insertBefore(first, new VarInsnNode(Opcodes.ALOAD, 0)); // Load item
+					m.instructions.insertBefore(first, new VarInsnNode(Opcodes.ILOAD, 1)); // load meta
+					m.instructions.insertBefore(first, new MethodInsnNode(Opcodes.INVOKESTATIC, "gregtech/asm/transformers/Thaumcraft_AspectLagFix", "getCachedItemHash", "(Lnet/minecraft/item/Item;I)I", false));
+					m.instructions.insertBefore(first, new InsnNode(Opcodes.DUP)); // duplicate return
+					m.instructions.insertBefore(first, new JumpInsnNode(Opcodes.IFEQ, first)); // If 0 jump to label0
+					m.instructions.insertBefore(first, new InsnNode(Opcodes.IRETURN));
+					m.instructions.insert(first, new InsnNode(Opcodes.POP)); // Pop the duplicate possible return value that's actually now 0
 
-		for (MethodNode m: classNode.methods) {
-			if (m.name.equals("generateItemHash")) { // Should check `desc` too but no ambiguity here anyway
-				LabelNode first = (LabelNode)m.instructions.get(0);
-				m.instructions.insertBefore(first, new VarInsnNode(Opcodes.ALOAD, 0)); // Load item
-				m.instructions.insertBefore(first, new VarInsnNode(Opcodes.ILOAD, 1)); // load meta
-				m.instructions.insertBefore(first, new MethodInsnNode(Opcodes.INVOKESTATIC, "gregtech/asm/transformers/Thaumcraft_AspectLagFix", "getCachedItemHash", "(Lnet/minecraft/item/Item;I)I", false));
-				m.instructions.insertBefore(first, new InsnNode(Opcodes.DUP)); // duplicate return
-				m.instructions.insertBefore(first, new JumpInsnNode(Opcodes.IFEQ, first)); // If 0 jump to label0
-				m.instructions.insertBefore(first, new InsnNode(Opcodes.IRETURN));
-				m.instructions.insert(first, new InsnNode(Opcodes.POP)); // Pop the duplicate possible return value that's actually now 0
-
-				for (AbstractInsnNode node = first.getNext(); node != null; node = node.getNext()) {
-					if (node instanceof InsnNode) {
-						InsnNode ret = (InsnNode)node;
-						if (ret.getOpcode() == Opcodes.IRETURN) {
-							m.instructions.insertBefore(ret, new VarInsnNode(Opcodes.ALOAD, 0)); // Load item, hash is already on the stack
-							m.instructions.insertBefore(ret, new VarInsnNode(Opcodes.ILOAD, 1)); // load meta
-							m.instructions.insertBefore(ret, new MethodInsnNode(Opcodes.INVOKESTATIC, "gregtech/asm/transformers/Thaumcraft_AspectLagFix", "setCachedItemHash", "(ILnet/minecraft/item/Item;I)I", false));
+					for (AbstractInsnNode node = first.getNext(); node != null; node = node.getNext()) {
+						if (node instanceof InsnNode) {
+							InsnNode ret = (InsnNode) node;
+							if (ret.getOpcode() == Opcodes.IRETURN) {
+								m.instructions.insertBefore(ret, new VarInsnNode(Opcodes.ALOAD, 0)); // Load item, hash is already on the stack
+								m.instructions.insertBefore(ret, new VarInsnNode(Opcodes.ILOAD, 1)); // load meta
+								m.instructions.insertBefore(ret, new MethodInsnNode(Opcodes.INVOKESTATIC, "gregtech/asm/transformers/Thaumcraft_AspectLagFix", "setCachedItemHash", "(ILnet/minecraft/item/Item;I)I", false));
+							}
 						}
 					}
 				}
 			}
-		}
 
-		ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
-		classNode.accept(writer);
-		return writer.toByteArray();
+			ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+			classNode.accept(writer);
+			return writer.toByteArray();
+		} else if (name.equals("thaumcraft.common.lib.crafting.ThaumcraftCraftingManager")) {
+			ClassNode classNode = new ClassNode();
+			ClassReader classReader = new ClassReader(basicClass);
+			classReader.accept(classNode, 0);
+
+			for (MethodNode m : classNode.methods) {
+				if (m.name.equals("getObjectTags")) { // Second most costly thing
+					LabelNode first = (LabelNode) m.instructions.get(0);
+					m.instructions.insertBefore(first, new VarInsnNode(Opcodes.ALOAD, 0)); // Load item
+					m.instructions.insertBefore(first, new MethodInsnNode(Opcodes.INVOKESTATIC, "gregtech/asm/transformers/Thaumcraft_AspectLagFix", "getCachedAspectTags", "(Lnet/minecraft/item/ItemStack;)Lthaumcraft/api/aspects/AspectList;", false));
+					m.instructions.insertBefore(first, new InsnNode(Opcodes.DUP)); // duplicate return
+					m.instructions.insertBefore(first, new JumpInsnNode(Opcodes.IFNULL, first)); // If 0 jump to label0
+					m.instructions.insertBefore(first, new InsnNode(Opcodes.ARETURN));
+					m.instructions.insert(first, new InsnNode(Opcodes.POP)); // Pop the duplicate possible return value that's actually now 0
+
+					for (AbstractInsnNode node = first.getNext(); node != null; node = node.getNext()) {
+						if (node instanceof InsnNode) {
+							InsnNode ret = (InsnNode) node;
+							if (ret.getOpcode() == Opcodes.ARETURN) {
+								m.instructions.insertBefore(ret, new VarInsnNode(Opcodes.ALOAD, 0)); // Load item, hash is already on the stack
+								m.instructions.insertBefore(ret, new MethodInsnNode(Opcodes.INVOKESTATIC, "gregtech/asm/transformers/Thaumcraft_AspectLagFix", "setCachedAspectTags", "(Lthaumcraft/api/aspects/AspectList;Lnet/minecraft/item/ItemStack;)Lthaumcraft/api/aspects/AspectList;", false));
+							}
+						}
+					}
+				}
+			}
+
+			ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+			classNode.accept(writer);
+			return writer.toByteArray();
+		} else {
+			return basicClass;
+		}
 	}
 
 	private static HashMap<Item, IntHashMap> cacheItemHash = new HashMap<>();
 
 	public static int getCachedItemHash(Item item, int meta) {
-		IntHashMap metaMap = cacheItemHash.get(item);
-		if (metaMap != null) {
-			Integer hash = (Integer)metaMap.lookup(meta);
-			if (hash != null) return hash;
+		if (item == null) return -1;
+		synchronized (cacheItemHash) {
+			IntHashMap metaMap = cacheItemHash.get(item);
+			if (metaMap != null) {
+				Integer hash = (Integer)metaMap.lookup(meta);
+				if (hash != null) return hash;
+				hash = (Integer)metaMap.lookup(-1);
+				if (hash != null) return hash;
+				int[] grouped = ThaumcraftApi.groupedObjectTags.get(Arrays.asList(item, meta));
+				if (grouped != null) {
+					hash = (Integer) metaMap.lookup(grouped[0]);
+					if (hash != null) return hash;
+				}
+			}
 		}
 		return 0;
 	}
 
 	public static int setCachedItemHash(int hash, Item item, int meta) {
-		IntHashMap metaMap = cacheItemHash.get(item);
-		if (metaMap == null) metaMap = cacheItemHash.put(item, new IntHashMap());
-		metaMap.addKey(meta, hash);
-		return hash;
+		synchronized (cacheItemHash) {
+			IntHashMap metaMap = cacheItemHash.get(item);
+			if (metaMap == null) cacheItemHash.put(item, metaMap = new IntHashMap());
+			metaMap.addKey(meta, hash);
+			return hash;
+		}
+	}
+
+	private static HashMap<Item, IntHashMap> cacheAspectTags = new HashMap<>();
+
+	public static AspectList getCachedAspectTags(ItemStack is) {
+		if (is == null || is.getItem() == null) return null;
+		synchronized (cacheAspectTags) {
+			IntHashMap metaMap = cacheAspectTags.get(is.getItem());
+			if (metaMap != null) {
+				AspectList aspects = (AspectList)metaMap.lookup(is.getItemDamage());
+				if (aspects != null) return aspects.copy(); // Ugh copy, why can't it just be immutable...
+			}
+		}
+		return null;
+	}
+
+	public static AspectList setCachedAspectTags(AspectList aspects, ItemStack is) {
+		synchronized (cacheAspectTags) {
+			if (aspects == null || is == null || is.getItem() == null) return null;
+			IntHashMap metaMap = cacheAspectTags.get(is.getItem());
+			if (metaMap == null) cacheAspectTags.put(is.getItem(), metaMap = new IntHashMap());
+			metaMap.addKey(is.getItemDamage(), aspects.copy());
+			return aspects;
+		}
 	}
 }


### PR DESCRIPTION
See commits for details, but in short:

* Added ability to pass program arguments to `runClient`/`runServer`, for example so you can pass a username (like in the `runClient`/`runServer` pass in `-PappArgs="['--username', 'MyUsername']"` to use the username `MyUsername` (or replace with whatever), so it will do things appropriately for that user, whether loading skins or giving stuff or whatever).  (I was tired of not having my skin when testing, lol...)

* Added a simple ASM transformer to cache the utterly slowest calculation for Thaumcraft scanning.  There might be more that can be done, but this was sufficient to entirely change Thaumcraft's scanning code in the Profiler from being the #1 time used by a substantial margin to not even appearing anymore.  Should test with the witching tools mod and thaumicnei aspect scanning enabled as that's a worst-case scenario with TC's Aspect scanning as every item gets scanned by NEI when searching (which usually takes 20-40 seconds at that point).  Actually... I'll test that now...  And yeah, not seeing any FPS drop, or even seeing it appear in the sampler at all, so that's a great sign!  Would prefer others to test too to see if there is anything else in thaumcraft that can be cached.