### PR TITLE
Fixed absorber and breeder rods not adhering to coolant based heat output modifier

### DIFF
--- a/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorCore1x1.java
+++ b/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorCore1x1.java
@@ -105,8 +105,8 @@ public class MultiTileEntityReactorCore1x1 extends MultiTileEntityReactorCore {
 			if (getReactorRodNeutronReaction(0)) mRunning = T;
 
 			int tDivider = 1;
-			if (MT.Na.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider *= 6;
-			else if (MT.Sn.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider *= 3;
+			if (MT.Na.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider = 6;
+			else if (MT.Sn.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider = 3;
 			mEnergy = UT.Code.divup(mEnergy - tEnergy, tDivider) + tEnergy;
 
 			oEnergy = mEnergy - tEnergy;

--- a/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorCore1x1.java
+++ b/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorCore1x1.java
@@ -104,6 +104,10 @@ public class MultiTileEntityReactorCore1x1 extends MultiTileEntityReactorCore {
 
 			if (getReactorRodNeutronReaction(0)) mRunning = T;
 
+			int tDivider = 1;
+			if (MT.Na.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider *= 6;
+			else if (MT.Sn.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider *= 3;
+			mEnergy = UT.Code.divup(mEnergy - tEnergy, tDivider) + tEnergy;
 
 			oEnergy = mEnergy - tEnergy;
 

--- a/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorCore2x2.java
+++ b/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorCore2x2.java
@@ -131,6 +131,11 @@ public class MultiTileEntityReactorCore2x2 extends MultiTileEntityReactorCore im
 			if (getReactorRodNeutronReaction(2)) mRunning = T;
 			if (getReactorRodNeutronReaction(3)) mRunning = T;
 
+			int tDivider = 1;
+			if (MT.Na.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider *= 6;
+			else if (MT.Sn.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider *= 3;
+			mEnergy = UT.Code.divup(mEnergy - tEnergy, tDivider) + tEnergy;
+
 			oEnergy = mEnergy - tEnergy;
 
 			if (mEnergy > 0) {

--- a/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorCore2x2.java
+++ b/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorCore2x2.java
@@ -132,8 +132,8 @@ public class MultiTileEntityReactorCore2x2 extends MultiTileEntityReactorCore im
 			if (getReactorRodNeutronReaction(3)) mRunning = T;
 
 			int tDivider = 1;
-			if (MT.Na.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider *= 6;
-			else if (MT.Sn.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider *= 3;
+			if (MT.Na.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider = 6;
+			else if (MT.Sn.mLiquid.isFluidEqual(mTanks[0].getFluid())) tDivider = 3;
 			mEnergy = UT.Code.divup(mEnergy - tEnergy, tDivider) + tEnergy;
 
 			oEnergy = mEnergy - tEnergy;

--- a/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorRodNuclear.java
+++ b/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorRodNuclear.java
@@ -186,10 +186,7 @@ public class MultiTileEntityReactorRodNuclear extends MultiTileEntityReactorRodB
 	@Override
 	// Gets called every Tick.
 	public boolean getReactorRodNeutronReaction(MultiTileEntityReactorCore aReactor, int aSlot, ItemStack aStack) {
-		int tDivider = 1;
-		if (MT.Na.mLiquid.isFluidEqual(aReactor.mTanks[0].getFluid())) tDivider *= 6;
-		else if (MT.Sn.mLiquid.isFluidEqual(aReactor.mTanks[0].getFluid())) tDivider *= 3;
-		aReactor.mEnergy += UT.Code.divup(aReactor.oNeutronCounts[aSlot], tDivider);
+		aReactor.mEnergy += aReactor.oNeutronCounts[aSlot];
 		if (mDurability <= 0) {
 			ST.meta(aStack, mDepleted);
 			ST.nbt(aStack, null);


### PR DESCRIPTION
I tested this change a bit and there seem to be no problems. The change only effects reactors using molten tin or molten sodium as coolant, which will now correctly output less heat on breeder and absorber rods.