### PR TITLE
Config option for Mob Farm?

### DIFF
--- a/src/main/java/gregapi/worldgen/dungeon/WorldgenDungeonGT.java
+++ b/src/main/java/gregapi/worldgen/dungeon/WorldgenDungeonGT.java
@@ -148,7 +148,7 @@ public class WorldgenDungeonGT extends WorldgenObject {
 		
 		byte[][] tRoomLayout = new byte[2+mMinSize+aRandom.nextInt(1+mMaxSize-mMinSize)][2+mMinSize+aRandom.nextInt(1+mMaxSize-mMinSize)];
 		
-		boolean[] tGeneratedKeys = new boolean[6];
+		boolean[] tGeneratedKeys = new boolean[5];
 		
 		if (!(mPortalNether                      && (aWorld.provider.dimensionId == DIM_OVERWORLD || aWorld.provider.dimensionId == DIM_NETHER))) tTags.add(TAG_PORTAL_NETHER);
 		if (!(mPortalEnd                         && (aWorld.provider.dimensionId == DIM_OVERWORLD || aWorld.provider.dimensionId == DIM_END   ))) tTags.add(TAG_PORTAL_END);


### PR DESCRIPTION
@GregoriusT 
Any chance a config option for the Mob Farm could be added?
 So that this can be avoided when you change the spawn layer for the Fort:
![image](https://user-images.githubusercontent.com/3237986/137592581-fd5df40c-2108-420e-b2e8-6cfd0929f23b.png)
Welcome to Mobspawn ala Fort.

I have tried to add it here but don't know if the coding is correct.

Havn't tested this edit ingame.