### PR TITLE
Nuclear Rework part 1

### DIFF
--- a/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorRodNuclear.java
+++ b/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorRodNuclear.java
@@ -176,10 +176,6 @@ public class MultiTileEntityReactorRodNuclear extends MultiTileEntityReactorRodB
 		}
 		aReactor.mNeutronCounts[aSlot] += mNeutronSelf;
 		long tEmission = mNeutronOther + UT.Code.divup(aReactor.oNeutronCounts[aSlot]-mNeutronSelf, mNeutronDiv);
-		long tDurabilityLoss = (tEmission * 4 + mNeutronSelf) < mNeutronMax ? 2000 : UT.Code.divup(8000 * (tEmission * 4 + mNeutronSelf), mNeutronMax);
-		if (oModerated) tDurabilityLoss *= 4;
-		mDurability = tDurabilityLoss > mDurability ? -1 : mDurability - tDurabilityLoss;
-		UT.NBT.set(aStack, writeItemNBT(aStack.hasTagCompound() ? aStack.getTagCompound() : UT.NBT.make()));
 		return UT.Code.bindInt(tEmission);
 	}
 	
@@ -187,6 +183,12 @@ public class MultiTileEntityReactorRodNuclear extends MultiTileEntityReactorRodB
 	// Gets called every Tick.
 	public boolean getReactorRodNeutronReaction(MultiTileEntityReactorCore aReactor, int aSlot, ItemStack aStack) {
 		aReactor.mEnergy += aReactor.oNeutronCounts[aSlot];
+
+		long tDurabilityLoss = aReactor.oNeutronCounts[aSlot] < mNeutronMax ? 100 : UT.Code.divup(400 * aReactor.oNeutronCounts[aSlot], mNeutronMax);
+		if (oModerated) tDurabilityLoss *= 4;
+		mDurability = tDurabilityLoss > mDurability ? -1 : mDurability - tDurabilityLoss;
+		UT.NBT.set(aStack, writeItemNBT(aStack.hasTagCompound() ? aStack.getTagCompound() : UT.NBT.make()));
+
 		if (mDurability <= 0) {
 			ST.meta(aStack, mDepleted);
 			ST.nbt(aStack, null);


### PR DESCRIPTION
This is my first of some changes I plan to make to the nuclear system. This change is a really simple but effective one to the durability system. Instead of comparing the neutron maximum to the total neutron output of a rod (self + 4 * emission), it is now compared to the number of neutrons on the fuel rod.

This makes the neutron maximum less complex and easier to understand, as the number you can measure will directly relate to it and you don't need to calculate things anymore.

It also has some important balance implications, mainly that neuron moderators are much less powerful/exploitable (efficiency wise) because the extra neutrons they create are now counted towards the neutron maximum, while absorber rods are more powerful than before, since the neutrons on them now don't count towards the neutron maximum like before.

This change has been tested to be working. Old builds should still work, although they may be less efficient (more durability loss by going over neutron maximum) than before, but since the changes only relate to the durability system, there is no chance for any reactor to blow up by these changes.

There are some other things I want to change in future pull requests, mainly rebalancing/reworking breeding (should also be backwards compatible for the most part, i.e. won't make reactors explode), a setting to disable the 1x1 reactor core recipe (also non-breaking, though I would like this setting to be default on), changing the coolant balance (this change can potentially cause explosions with some reactor coolants that get buffed, so that change is definitely debatable) and potentially some changes making getting nuclear fuel a little harder.