### PR TITLE
Fuel Rod Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All the Reactor Stuff Erik did:
 [CHANGED] Setting the Secondary Facing of a Reactor Core to the same side as the Primary Facing will now disable the Secondary Facing.
 [ADDED] Tritium can now be turned into Tritiated Water, useful as a reactor coolant when obtaining Tritium from Lithium breeder rods.
 [FIXED] Fuel rods with neutron counts at the exact neutron maximum now won't have their duration effected. 
+[FIXED] First second of neutron output of fuel rods being potentially lower than emission stat (in some cases even negative)
 
 
 6.14.23:

--- a/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorRodNuclear.java
+++ b/src/main/java/gregtech/tileentity/energy/reactors/MultiTileEntityReactorRodNuclear.java
@@ -195,7 +195,7 @@ public class MultiTileEntityReactorRodNuclear extends MultiTileEntityReactorRodB
 			tNeutronDiv -= 1;
 		}
 		aReactor.mNeutronCounts[aSlot] += tNeutronSelf;
-		long tEmission = tNeutronOther + UT.Code.divup(aReactor.oNeutronCounts[aSlot]-tNeutronSelf, tNeutronDiv);
+		long tEmission = tNeutronOther + UT.Code.divup(Math.max(aReactor.oNeutronCounts[aSlot]-tNeutronSelf, 0), tNeutronDiv);
 		return UT.Code.bindInt(tEmission);
 	}
 	


### PR DESCRIPTION
Fixes a long standing bug that would cause the first second of the emission of a fuel rod to have less neutrons than the neutron emission stat. With fuel rods stats featuring a higher self stat than emission stat this could even lead to negative neutrons.

I tested this change on a number of reactor designs and it had no impact on their "final" neutron counts, apart from the (new unreleased stats) Co-60 rod, which could by being able to output negative neutrons cause a positive neutron output through some strange interactions of the bug, which is the reason I discovered the bug in the first place.