### PR TITLE
Update OreDictPrefixCondition.java

### DIFF
--- a/src/main/java/gregapi/oredict/OreDictPrefixCondition.java
+++ b/src/main/java/gregapi/oredict/OreDictPrefixCondition.java
@@ -30,18 +30,18 @@ import gregapi.code.TagData;
  * A Collection of Classes, which check for certain Prefix Conditions.
  */
 public class OreDictPrefixCondition {
-	public static ICondition<OreDictPrefix> tag     (TagData... aTags)      {return new TagDataContainsAll(aTags);}
-	public static ICondition<OreDictPrefix> tagnor  (TagData... aTags)      {return new TagDataContainsNone(aTags);}
+	public static ICondition<OreDictMaterial> tag     (TagData... aTags)      {return new TagDataContainsAll(aTags);}
+	public static ICondition<OreDictMaterial> tagnor  (TagData... aTags)      {return new TagDataContainsNone(aTags);}
 	
-	private static class TagDataContainsAll implements ICondition<OreDictPrefix> {
+	private static class TagDataContainsAll implements ICondition<OreDictMaterial> {
 		private final TagData[] mTags;
 		public TagDataContainsAll(TagData... aTags) {mTags = aTags;}
-		@Override public boolean isTrue(OreDictPrefix aPrefix) {return aPrefix.containsAll(mTags);}
+		@Override public boolean isTrue(OreDictMaterial aPrefix) {return aPrefix.containsAll(mTags);}
 	}
 	
-	private static class TagDataContainsNone implements ICondition<OreDictPrefix> {
+	private static class TagDataContainsNone implements ICondition<OreDictMaterial> {
 		private final TagData[] mTags;
 		public TagDataContainsNone(TagData... aTags) {mTags = aTags;}
-		@Override public boolean isTrue(OreDictPrefix aPrefix) {for (TagData tTag : mTags) if (aPrefix.contains(tTag)) return F; return T;}
+		@Override public boolean isTrue(OreDictMaterial aPrefix) {for (TagData tTag : mTags) if (aPrefix.contains(tTag)) return F; return T;}
 	}
 }


### PR DESCRIPTION
Previous code would cause ClassCastException: 
gregapi.oredict.OreDictMaterial cannot be cast to gregapi.oredict.OreDictPrefix
	at gregapi.oredict.OreDictPrefixCondition$TagDataContainsNone.isTrue(OreDictPrefixCondition.java:42)
	at gregapi.oredict.OreDictPrefix.isGeneratingItem(OreDictPrefix.java:364)
