### PR TITLE
Fluids should not be observed through the EnderGarbageBin

### DIFF
--- a/src/main/java/gregtech/tileentity/inventories/MultiTileEntityEnderGarbageBin.java
+++ b/src/main/java/gregtech/tileentity/inventories/MultiTileEntityEnderGarbageBin.java
@@ -90,7 +90,7 @@ public class MultiTileEntityEnderGarbageBin extends TileEntityBase07Paintable im
 	
 	@Override
 	protected IFluidTank[] getFluidTanks2(byte aSide) {
-		return GarbageGT.GARBAGE_FLUIDS.isEmpty() ? new FluidTankGT().AS_ARRAY : GarbageGT.GARBAGE_FLUIDS.toArray(ZL_FT);
+		return new FluidTankGT().AS_ARRAY;
 	}
 	
 	@Override


### PR DESCRIPTION
When I play GT with the GTNH version of [WailaPlugins](https://github.com/GTNewHorizons/WAILAPlugins) and [HoloInventory](https://github.com/GTNewHorizons/HoloInventory), all fluids in the garbage dimension are displayed when I look at the EnderGarbageBin (as shown below, upper layer is Waila and lower layer is HoloInventory)

![F1FC150D1A87360357DE4EDACE6C742C](https://github.com/GregTech6/gregtech6/assets/50107074/1672e19c-9a86-421a-bcb0-c28b03ce7dbf)

(Sorry, I forgot to switch to English before taking the screenshot...)

So I'm wondering if it's unnecessary to implement this feature to observe fluids in the garbage dimension on the EnderGarbageBin.

If you think this feature is necessary, could you please tell me why? I will then close this PR.
