### PR TITLE
make draconium less abundant in overworld

### DIFF
--- a/src/main/java/gregtech/loaders/b/Loader_Worldgen.java
+++ b/src/main/java/gregtech/loaders/b/Loader_Worldgen.java
@@ -97,7 +97,7 @@ public class Loader_Worldgen implements Runnable {
 		, new StoneLayerOres(MT.Coal                                    , F, U16,  0, 32, ST.block(MD.EtFu, "deepslate_coal_ore"), BIOMES_PLAINS, BIOMES_SHROOM)
 		, MD.Salt     .mLoaded ? new StoneLayerOres(MT.NaCl             , F, U32, 20, 32, ST.block(MD.Salt, "saltDeepslateOre")) : null
 		,!MT.Nikolite .mHidden ? new StoneLayerOres(MT.Nikolite         , F, U32,  0, 20, ST.block(MD.EtFu, "deepslate_projred_ore"), 3, ST.block(MD.EtFu, "deepslate_bluepower_ore"), 0) : null
-		, MD.DE       .mLoaded ? new StoneLayerOres(MT.Draconium        , F, U64,  0,  7, ST.block(MD.EtFu, "deepslate_draconium_ore"), 0) : null
+		, MD.DE       .mLoaded ? new StoneLayerOres(MT.Draconium        , F, U144,  0,  7, ST.block(MD.EtFu, "deepslate_draconium_ore"), 0, BIOMES_MAGICAL) : null
 		, MD.HEX      .mLoaded ? new StoneLayerOres(MT.HexoriumBlack    , F, U32,  0, 16) : null
 		, MD.HEX      .mLoaded ? new StoneLayerOres(MT.HexoriumWhite    , F, U32,  0, 16) : null
 		, MD.MET      .mLoaded ? new StoneLayerOres(MT.DeepIron         , F, U16,  0, 16) : null


### PR DESCRIPTION
the GT6 deepslate layers currently spawn a lot of draconium in a large area (it's not as dense locally but has more average density than a single ore deposit)

with DE installed you already get plenty from the end in comets; i set it here to be 2.25 times less frequent and only appear in magical biomes (since it's much more powerful than the magical ores that already appear in those biomes' deepslate layers)