### PR TITLE
Add NTM paraffin wax to oredict

### DIFF
--- a/src/main/java/gregapi/load/LoaderUnificationTargets.java
+++ b/src/main/java/gregapi/load/LoaderUnificationTargets.java
@@ -249,6 +249,7 @@ public class LoaderUnificationTargets implements Runnable {
 		OreDictManager.INSTANCE.setTarget(OP.dust           , MT.Ce                     , MD.HBM, "item.powder_cerium"              , 0);
 		OreDictManager.INSTANCE.setTarget(OP.nugget         , MT.Ce                     , MD.HBM, "item.fragment_cerium"            , 0);
 		OreDictManager.INSTANCE.setTarget(OP.dust           , MT.Br                     , MD.HBM, "item.powder_bromine"             , 0);
+		OreDictManager.INSTANCE.setTarget(OP.dust           , MT.WaxParaffin            , MD.HBM, "item.oil_tar"                    , 5);
 		OreDictManager.INSTANCE.setTarget(OP.ingot          , MT.Adamantine             , MD.MET, "adamantine.ingot", 0);
 		OreDictManager.INSTANCE.setTarget(OP.ingot          , MT.Alduorite              , MD.MET, "alduorite.ingot", 0);
 		OreDictManager.INSTANCE.setTarget(OP.ingot          , MT.Amordrine              , MD.MET, "amordrine.ingot", 0);


### PR DESCRIPTION
This treats Nuclear Tech Mod paraffin wax to be same as GT6 paraffin wax for GT6 wax recipes, steam cracking etc
<img width="552" height="453" alt="image" src="https://github.com/user-attachments/assets/11ef6263-1a1c-4a44-b849-9d2ba534ac2f" />

tested in game and shows up in NEI recipes etc

Metadata ID should stay 5 unless this enum changes
https://github.com/HbmMods/Hbm-s-Nuclear-Tech-GIT/blob/master/src/main/java/com/hbm/items/ItemEnums.java#L17-L24