### PR TITLE
Buff BioDiesel fuel values and add Mixer recipes for vegetable oils

### DIFF
--- a/src/main/java/gregtech/loaders/b/Loader_Fuels.java
+++ b/src/main/java/gregtech/loaders/b/Loader_Fuels.java
@@ -127,8 +127,8 @@ public class Loader_Fuels implements Runnable {
 		FM.Engine       .addRecipe0(T, - 16, 12, tFuel                                       , FL.CarbonDioxide.make(1), ZL_IS);
 		}
 		for (FluidStack tFuel : FL.BioDiesel.list(1)) {
-		FM.Burn         .addRecipe0(T, - 16,  9, tFuel                                       , FL.CarbonDioxide.make(1), ZL_IS);
-		FM.Engine       .addRecipe0(T, - 16, 12, tFuel                                       , FL.CarbonDioxide.make(1), ZL_IS);
+		FM.Burn         .addRecipe0(T, - 16, 18, tFuel                                       , FL.CarbonDioxide.make(1), ZL_IS);
+		FM.Engine       .addRecipe0(T, - 16, 24, tFuel                                       , FL.CarbonDioxide.make(1), ZL_IS);
 		}
 		for (FluidStack tFuel : FL.BioFuel.list(1)) {
 		FM.Burn         .addRecipe0(T, - 64,  9, tFuel                                       , FL.CarbonDioxide.make(1), ZL_IS);

--- a/src/main/java/gregtech/loaders/c/Loader_Recipes_Chem.java
+++ b/src/main/java/gregtech/loaders/c/Loader_Recipes_Chem.java
@@ -560,5 +560,11 @@ public class Loader_Recipes_Chem implements Runnable {
 		RM.Drying       .addRecipe1(T, 16, 2000, OP.dust.mat(MT.OREMATS.Perlite   ,  1), NF, FL.DistW.make( 1000), OP.dust.mat(MT.Obsidian, 1));
 		for (OreDictMaterial tMat : ANY.Clay.mToThis)
 		RM.Drying       .addRecipe1(T, 16, 1000, OP.dust.mat(tMat                 ,  1), NF, FL.DistW.make(  500), OP.dust.mat(MT.Ceramic , 1));
+
+		if (FL.BioDiesel.exists() && FL.BioEthanol.exists()) {
+			for (String tOil : FluidsGT.COOKING_OIL) if (FL.exists(tOil)) {
+				RM.Mixer.addRecipe0(T, 16, 16, FL.array(FL.make(tOil, 8), FL.BioEthanol.make(8)), FL.BioDiesel.make(16), ZL_IS);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Increased BioDiesel fuel value to 288 HU/L (Burnable) and 384 RU/L (Engine) to better reflect its production cost, same as ethanol doesn't really make sense.

Added Mixer recipes (8mB Vegetable Oil + 8mB Ethanol -> 16mB BioDiesel) for all fluids registered in FluidsGT.COOKING_OIL at 16 ticks (16 EU/t). This provides a 1:1 throughput balance with the single-block Distillery.